### PR TITLE
perf(test): use cargo nextest to speed up CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+
+      - name: "Install cargo nextest"
+        uses: taiki-e/install-action@be7c31b6745feec79dec5eb79178466c0670bb2d # v2
+        with:
+          tool: cargo-nextest
       
       - name: Install system dependencies
         run: |
@@ -30,4 +35,4 @@ jobs:
         uses: Swatinem/rust-cache@v2
       
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo nextest run --verbose


### PR DESCRIPTION
## Description

Use cargo-nextest in CI workflow for faster test runs

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

(Run locally)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- (N/A) I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- (N/A) I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- (N/A) Any dependent changes have been merged and published in downstream modules

## Additional context

- I used the immutable hash of the GitHub Action tag ("be7c31b...") rather than the mutable name of the tag ("v2") to prevent unexpected supply chain bugs. The cargo-nextest binary installed will never change unexpectedly.
- Speedup is maybe 5x or more