### PR TITLE
build(openblas-src): lax v0.17 dgemm upgrade

### DIFF
--- a/scirs2-stats/src/lib.rs
+++ b/scirs2-stats/src/lib.rs
@@ -281,6 +281,7 @@
 //! // Generate a random permutation
 //! let permutation = sampling::permutation(&data.view(), Some(123)).unwrap();
 //! ```
+extern crate openblas_src;
 
 // Export error types
 pub mod error;


### PR DESCRIPTION
Closes https://github.com/cool-japan/scirs/issues/10

## Description

Allow lax v0.17 version bump without the blas dgemm error described in #10

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
- [x] Integration tests

(Submitting PR to see if tests pass)