### PR TITLE
build(openblas-src): lax v0.17 BLAS linking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential libopenblas-dev pkg-config
+          sudo apt-get install -y build-essential libopenblas-dev pkg-config libfreetype6-dev libfontconfig1-dev
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ serde_json = "1.0"
 
 # Common dependencies for specific modules
 nalgebra = "0.33.2"
-ndarray-linalg = { version = "0.16.0", features = ["openblas-static"] }
+ndarray-linalg = { version = "0.17.0", features = ["openblas-static"] }
 rustfft = "6.2.0"
 argmin = "0.10.0"
 sprs = "0.11.3"

--- a/scirs2-graph/Cargo.toml
+++ b/scirs2-graph/Cargo.toml
@@ -18,6 +18,8 @@ ndarray = { version = "0.16.1", features = ["serde", "rayon"] }
 num-traits = "0.2.19"
 num-complex = "0.4.6"
 thiserror = "2.0.12"
+openblas-src = "*"
+blas = "*"
 
 # Graph processing specific dependencies
 petgraph = "0.6"

--- a/scirs2-graph/Cargo.toml
+++ b/scirs2-graph/Cargo.toml
@@ -18,7 +18,7 @@ ndarray = { version = "0.16.1", features = ["serde", "rayon"] }
 num-traits = "0.2.19"
 num-complex = "0.4.6"
 thiserror = "2.0.12"
-openblas-src = "*"
+openblas-src = "0.10.11"
 blas = "0.23.0"
 
 # Graph processing specific dependencies

--- a/scirs2-graph/Cargo.toml
+++ b/scirs2-graph/Cargo.toml
@@ -19,7 +19,7 @@ num-traits = "0.2.19"
 num-complex = "0.4.6"
 thiserror = "2.0.12"
 openblas-src = "*"
-blas = "*"
+blas = "0.23.0"
 
 # Graph processing specific dependencies
 petgraph = "0.6"

--- a/scirs2-graph/src/lib.rs
+++ b/scirs2-graph/src/lib.rs
@@ -13,6 +13,9 @@
 
 #![warn(missing_docs)]
 
+extern crate blas;
+extern crate openblas_src;
+
 pub mod algorithms;
 pub mod base;
 pub mod error;

--- a/scirs2-linalg/Cargo.toml
+++ b/scirs2-linalg/Cargo.toml
@@ -25,8 +25,8 @@ approx = "0.5.1"
 wide = "0.7.32"
 rayon = "1.10.0"
 scirs2-autograd = { path = "../scirs2-autograd", version = "0.1.0-alpha.2", optional = true }
-openblas-src = "*"
-blas = "*"
+openblas-src = "0.10.11"
+blas = "0.23.0"
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/scirs2-linalg/Cargo.toml
+++ b/scirs2-linalg/Cargo.toml
@@ -25,6 +25,8 @@ approx = "0.5.1"
 wide = "0.7.32"
 rayon = "1.10.0"
 scirs2-autograd = { path = "../scirs2-autograd", version = "0.1.0-alpha.2", optional = true }
+openblas-src = "*"
+blas = "*"
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/scirs2-linalg/src/lib.rs
+++ b/scirs2-linalg/src/lib.rs
@@ -82,6 +82,8 @@
 //! // Fast matrix multiplication for large matrices
 //! let c = blas_accelerated::matmul(&a.view(), &b.view()).unwrap();
 //! ```
+extern crate blas as _;
+extern crate openblas_src;
 
 // Export error types
 pub mod error;

--- a/scirs2-optimize/Cargo.toml
+++ b/scirs2-optimize/Cargo.toml
@@ -17,7 +17,7 @@ ndarray = { version = "0.16.1", features = ["serde", "rayon"] }
 num-traits = "0.2.19"
 num-complex = "0.4.6"
 thiserror = "2.0.12"
-openblas-src = "*"
+openblas-src = "0.10.11"
 
 # Optimization specific dependencies
 argmin = "0.10.0"

--- a/scirs2-optimize/Cargo.toml
+++ b/scirs2-optimize/Cargo.toml
@@ -17,6 +17,7 @@ ndarray = { version = "0.16.1", features = ["serde", "rayon"] }
 num-traits = "0.2.19"
 num-complex = "0.4.6"
 thiserror = "2.0.12"
+openblas-src = "*"
 
 # Optimization specific dependencies
 argmin = "0.10.0"

--- a/scirs2-optimize/src/lib.rs
+++ b/scirs2-optimize/src/lib.rs
@@ -118,6 +118,8 @@
 //! let bounds2 = Bounds::from_vecs(lb, ub).unwrap();
 //! ```
 
+extern crate openblas_src;
+
 // Export error types
 pub mod error;
 pub use error::{OptimizeError, OptimizeResult};

--- a/scirs2-signal/Cargo.toml
+++ b/scirs2-signal/Cargo.toml
@@ -16,6 +16,7 @@ ndarray = { version = "0.16.1", features = ["serde", "rayon"] }
 num-traits = "0.2.19"
 num-complex = "0.4.6"
 thiserror = "2.0.12"
+openblas-src = "*"
 
 # Signal processing specific dependencies
 rustfft = "6.2.0"

--- a/scirs2-signal/Cargo.toml
+++ b/scirs2-signal/Cargo.toml
@@ -16,7 +16,7 @@ ndarray = { version = "0.16.1", features = ["serde", "rayon"] }
 num-traits = "0.2.19"
 num-complex = "0.4.6"
 thiserror = "2.0.12"
-openblas-src = "*"
+openblas-src = "0.10.11"
 
 # Signal processing specific dependencies
 rustfft = "6.2.0"

--- a/scirs2-signal/src/lib.rs
+++ b/scirs2-signal/src/lib.rs
@@ -34,6 +34,8 @@
 //! // let filtered = filtfilt(&b, &a, &signal).unwrap();
 //! ```
 
+extern crate openblas_src;
+
 // Export error types
 pub mod error;
 pub use error::{SignalError, SignalResult};

--- a/scirs2-stats/Cargo.toml
+++ b/scirs2-stats/Cargo.toml
@@ -18,6 +18,7 @@ thiserror = "2.0.12"
 ndarray-linalg = { version = "0.17.0", features = ["openblas-static"] }
 scirs2-core = { version = "0.1.0-alpha.2", path = "../scirs2-core", features = ["validation", "parallel", "simd", "linalg", "openblas"] }
 scirs2-linalg = { version = "0.1.0-alpha.2", path = "../scirs2-linalg" }
+openblas-src = "*"
 
 # Statistics specific dependencies
 rand = "0.9.0"

--- a/scirs2-stats/Cargo.toml
+++ b/scirs2-stats/Cargo.toml
@@ -15,7 +15,7 @@ ndarray = { version = "0.16.1", features = ["serde", "rayon"] }
 num-traits = "0.2.19"
 num-complex = "0.4.6"
 thiserror = "2.0.12"
-ndarray-linalg = { version = "0.16.0", features = ["openblas-static"] }
+ndarray-linalg = { version = "0.17.0", features = ["openblas-static"] }
 scirs2-core = { version = "0.1.0-alpha.2", path = "../scirs2-core", features = ["validation", "parallel", "simd", "linalg", "openblas"] }
 scirs2-linalg = { version = "0.1.0-alpha.2", path = "../scirs2-linalg" }
 

--- a/scirs2-stats/Cargo.toml
+++ b/scirs2-stats/Cargo.toml
@@ -18,7 +18,7 @@ thiserror = "2.0.12"
 ndarray-linalg = { version = "0.17.0", features = ["openblas-static"] }
 scirs2-core = { version = "0.1.0-alpha.2", path = "../scirs2-core", features = ["validation", "parallel", "simd", "linalg", "openblas"] }
 scirs2-linalg = { version = "0.1.0-alpha.2", path = "../scirs2-linalg" }
-openblas-src = "*"
+openblas-src = "0.10.11"
 
 # Statistics specific dependencies
 rand = "0.9.0"

--- a/scirs2-stats/src/lib.rs
+++ b/scirs2-stats/src/lib.rs
@@ -281,6 +281,7 @@
 //! // Generate a random permutation
 //! let permutation = sampling::permutation(&data.view(), Some(123)).unwrap();
 //! ```
+extern crate openblas_src;
 
 // Export error types
 pub mod error;


### PR DESCRIPTION
## Description

- This PR modifies the dependabot upgrade to add blas and openblas-src `extern crate` statements which will tell cargo to explicitly link to BLAS, without which the linker gives `undefined symbol` errors for BLAS symbols like `cblas_dgemv`
- Initially I have set the versions as "*" just to check it works, I will amend these to use the proper versions from the lockfile now

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Existing tests all pass :tada: