### PR TITLE
Fix: matrix_exp by using correct Pade coefficients

### DIFF
--- a/scirs2-linalg/tests/enhanced_op_tests.rs
+++ b/scirs2-linalg/tests/enhanced_op_tests.rs
@@ -113,6 +113,96 @@ fn test_complex_matrix_operations() {
     assert_abs_diff_eq!(exp_zero[[1, 0]].im, 0.0, epsilon = 1e-10);
     assert_abs_diff_eq!(exp_zero[[1, 1]].re, 1.0, epsilon = 1e-10);
     assert_abs_diff_eq!(exp_zero[[1, 1]].im, 0.0, epsilon = 1e-10);
+
+    let mut non_trivial = array![
+        [
+            Complex::new(0.25, 0.0),
+            Complex::new(0.0, 0.0),
+            Complex::new(0.0, 0.0),
+            Complex::new(0.0, 0.0)
+        ],
+        [
+            Complex::new(0.0, 0.0),
+            Complex::new(-0.25, 0.0),
+            Complex::new(0.5, 0.0),
+            Complex::new(0.0, 0.0)
+        ],
+        [
+            Complex::new(0.0, 0.0),
+            Complex::new(0.5, 0.0),
+            Complex::new(-0.25, 0.0),
+            Complex::new(0.0, 0.0)
+        ],
+        [
+            Complex::new(0.0, 0.0),
+            Complex::new(0.0, 0.0),
+            Complex::new(0.0, 0.0),
+            Complex::new(0.25, 0.0)
+        ],
+    ];
+    non_trivial *= Complex::new(0.0, -0.05);
+    let exp_non_trivial = matrix_exp(&non_trivial.view()).unwrap();
+
+    assert_abs_diff_eq!(
+        exp_non_trivial[[0, 0]].re,
+        0.9999218760172473575,
+        epsilon = 1e-10
+    );
+    assert_abs_diff_eq!(
+        exp_non_trivial[[0, 0]].im,
+        -0.01249967448170978893,
+        epsilon = 1e-10
+    );
+    assert_abs_diff_eq!(
+        exp_non_trivial[[1, 1]].re,
+        0.9996094167054230262,
+        epsilon = 1e-10
+    );
+    assert_abs_diff_eq!(
+        exp_non_trivial[[1, 1]].im,
+        0.01249576853687523956,
+        epsilon = 1e-10
+    );
+    assert_abs_diff_eq!(
+        exp_non_trivial[[2, 2]].re,
+        0.9996094167054230262,
+        epsilon = 1e-10
+    );
+    assert_abs_diff_eq!(
+        exp_non_trivial[[2, 2]].im,
+        0.01249576853687523956,
+        epsilon = 1e-10
+    );
+    assert_abs_diff_eq!(
+        exp_non_trivial[[3, 3]].re,
+        0.9999218760172473575,
+        epsilon = 1e-10
+    );
+    assert_abs_diff_eq!(
+        exp_non_trivial[[3, 3]].im,
+        -0.01249967448170978893,
+        epsilon = 1e-10
+    );
+    assert_abs_diff_eq!(
+        exp_non_trivial[[1, 2]].re,
+        0.0003124593118243262999,
+        epsilon = 1e-10
+    );
+    assert_abs_diff_eq!(
+        exp_non_trivial[[1, 2]].im,
+        -0.02499544301858503295,
+        epsilon = 1e-10
+    );
+    assert_abs_diff_eq!(
+        exp_non_trivial[[2, 1]].re,
+        0.0003124593118243262999,
+        epsilon = 1e-10
+    );
+    assert_abs_diff_eq!(
+        exp_non_trivial[[2, 1]].im,
+        -0.02499544301858502848,
+        epsilon = 1e-10
+    );
 }
 
 // Random matrix generation test is disabled until random module


### PR DESCRIPTION
Also adding a non-trivial matrix exponentiation test.
See equivalence of recursive product formula and explicit for coefficients:
https://www.desmos.com/calculator/vkaxjhg28o
Fixes #27. Also fixing the order of matrix multiplication of numerator and denominator.

## Description
<!-- Briefly describe the changes in this PR -->

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] AI/ML related functionality

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes -->
- [x] Unit tests
- [ ] Integration tests
- [ ] Performance tests (if relevant)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional context
<!-- Add any other context about the PR here -->