### PR TITLE
Remove debug println! calls from ConvertToTensor::compute

### DIFF
--- a/scirs2-autograd/src/tensor_ops/const_gen_ops.rs
+++ b/scirs2-autograd/src/tensor_ops/const_gen_ops.rs
@@ -82,37 +82,7 @@ impl<T: Float> op::Op<T> for Ones {
 
 impl<T: Float> op::Op<T> for ConvertToTensor<T> {
     fn compute(&self, ctx: &mut crate::op::ComputeContext<T>) -> Result<(), crate::op::OpError> {
-        // Save the original array shape for debugging
-        let shape = self.arr.shape();
-        println!(
-            "ConvertToTensor: Input array shape: {:?}, ndim: {}",
-            shape,
-            self.arr.ndim()
-        );
-
-        // Always preserve the original array's shape exactly
-        let output = self.arr.clone();
-
-        // Check the created array
-        println!(
-            "DEBUG: Created tensor with shape: {:?}, ndim: {}",
-            output.shape(),
-            output.ndim()
-        );
-
-        // Additional debugging info
-        if output.ndim() == 0 {
-            println!("DEBUG: Scalar tensor value: {}", output[[]]);
-        } else if output.ndim() == 1 && !output.is_empty() {
-            println!("DEBUG: Vector tensor first element: {}", output[[0]]);
-        } else if output.ndim() == 2 && output.shape()[0] > 0 && output.shape()[1] > 0 {
-            println!("DEBUG: Matrix tensor first element: {}", output[[0, 0]]);
-        } else {
-            println!("DEBUG: Tensor cannot display elements (empty or higher dimension)");
-        }
-
-        // Append the output, preserving the exact shape
-        ctx.append_output(output);
+        ctx.append_output(self.arr.clone());
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- Remove ~30 lines of println! debug statements from ConvertToTensor::compute in scirs2-autograd/src/tensor_ops/const_gen_ops.rs
- These debug prints fired on every tensor creation, producing ~64MB of console output for a simple SVI run
- Replace with the minimal implementation: just clone and append the array

## Details

The ConvertToTensor::compute method had been instrumented with debug prints for shape, ndim, scalar values, vector first elements, and matrix first elements. These were useful during initial development but should not remain in production code, especially since they execute on every single tensor creation operation.

## Test plan
- [ ] Verify that tensor creation still works correctly (no behavioral change, only print removal)
- [ ] Confirm that SVI runs no longer produce excessive console output

Generated with Claude Code