### PR TITLE
Interpolate: Add `Nearest` variant to interpnd ExtrapolateMode

### DIFF
--- a/scirs2-interpolate/src/boundarymode.rs
+++ b/scirs2-interpolate/src/boundarymode.rs
@@ -192,6 +192,9 @@ impl<T: Float + std::fmt::Display> BoundaryParameters<T> {
                         // Return NaN for _points outside the interpolation domain
                         Ok(BoundaryResult::DirectValue(T::nan()))
                     }
+                    ExtrapolateMode::Nearest => {
+                        Ok(BoundaryResult::MappedPoint(self.lower_bound))
+                    }
                 }
             }
             BoundaryMode::ZeroGradient => {
@@ -308,6 +311,9 @@ impl<T: Float + std::fmt::Display> BoundaryParameters<T> {
                     ExtrapolateMode::Nan => {
                         // Return NaN for _points outside the interpolation domain
                         Ok(BoundaryResult::DirectValue(T::nan()))
+                    }
+                    ExtrapolateMode::Nearest => {
+                        Ok(BoundaryResult::MappedPoint(self.upper_bound))
                     }
                 }
             }

--- a/scirs2-interpolate/src/hermite.rs
+++ b/scirs2-interpolate/src/hermite.rs
@@ -359,6 +359,10 @@ impl<T: Float + std::fmt::Display> HermiteSpline<T> {
                     // Return NaN for points outside the interpolation domain
                     return Ok(T::nan());
                 }
+                ExtrapolateMode::Nearest => {
+                    let clamped = xval.max(self.x[0]).min(self.x[n - 1]);
+                    return self.evaluate_single(clamped);
+                }
             }
         }
 
@@ -451,6 +455,10 @@ impl<T: Float + std::fmt::Display> HermiteSpline<T> {
                     // Return NaN for points outside the interpolation domain
                     return Ok(T::nan());
                 }
+                ExtrapolateMode::Nearest => {
+                    let clamped = xval.max(self.x[0]).min(self.x[n - 1]);
+                    return self.derivative_single(deriv_order, clamped);
+                }
             }
         }
 
@@ -529,6 +537,11 @@ impl<T: Float + std::fmt::Display> HermiteSpline<T> {
                 }
                 ExtrapolateMode::Nan => {
                     return Ok(T::nan());
+                }
+                ExtrapolateMode::Nearest => {
+                    let a_clamped = a.max(self.x[0]).min(self.x[n - 1]);
+                    let b_clamped = b.max(self.x[0]).min(self.x[n - 1]);
+                    return self.integrate(a_clamped, b_clamped);
                 }
             }
         }

--- a/scirs2-interpolate/src/interpnd.rs
+++ b/scirs2-interpolate/src/interpnd.rs
@@ -27,7 +27,9 @@ pub enum ExtrapolateMode {
     Nan,
     /// Raise an error for points outside the interpolation domain
     Error,
-    /// Extrapolate based on the nearest edge points
+    /// Clamp out-of-range coordinates to the grid boundary before interpolating
+    Nearest,
+    /// Extrapolate beyond the grid using the boundary cell's slope
     Extrapolate,
 }
 
@@ -248,7 +250,7 @@ impl<F: crate::traits::InterpolationFloat> RegularGridInterpolator<F> {
         let mut weights = Vec::with_capacity(self.points.len());
 
         for (dim, dim_points) in self.points.iter().enumerate() {
-            let x = point[dim];
+            let mut x = point[dim];
 
             // Check if point is outside the domain
             if x < dim_points[0] || x > dim_points[dim_points.len() - 1] {
@@ -265,8 +267,10 @@ impl<F: crate::traits::InterpolationFloat> RegularGridInterpolator<F> {
                     ExtrapolateMode::Nan => {
                         return Ok(F::nan());
                     }
-                    // For extrapolate and constant modes, we'll find the nearest edge
-                    _ => {}
+                    ExtrapolateMode::Nearest => {
+                        x = x.max(dim_points[0]).min(dim_points[dim_points.len() - 1]);
+                    }
+                    ExtrapolateMode::Extrapolate => {}
                 }
             }
 

--- a/scirs2-interpolate/src/multiscale.rs
+++ b/scirs2-interpolate/src/multiscale.rs
@@ -147,6 +147,7 @@ impl<
             ExtrapolateMode::Error => BSplineExtrapolateMode::Error,
             ExtrapolateMode::Extrapolate => BSplineExtrapolateMode::Extrapolate,
             ExtrapolateMode::Nan => BSplineExtrapolateMode::Nan,
+            ExtrapolateMode::Nearest => BSplineExtrapolateMode::Extrapolate,
         };
 
         let initial_spline = make_lsq_bspline(
@@ -250,6 +251,7 @@ impl<
             ExtrapolateMode::Error => BSplineExtrapolateMode::Error,
             ExtrapolateMode::Extrapolate => BSplineExtrapolateMode::Extrapolate,
             ExtrapolateMode::Nan => BSplineExtrapolateMode::Nan,
+            ExtrapolateMode::Nearest => BSplineExtrapolateMode::Extrapolate,
         };
 
         // Instead of using the same coefficients with more knots (which breaks the constraint),

--- a/scirs2-interpolate/src/tension.rs
+++ b/scirs2-interpolate/src/tension.rs
@@ -298,6 +298,10 @@ impl<T: Float + std::fmt::Display + FromPrimitive> TensionSpline<T> {
                     // Return NaN for points outside the interpolation domain
                     return Ok(T::nan());
                 }
+                ExtrapolateMode::Nearest => {
+                    let clamped = xval.max(self.x[0]).min(self.x[n - 1]);
+                    return self.evaluate_single(clamped);
+                }
             }
         }
 
@@ -398,6 +402,10 @@ impl<T: Float + std::fmt::Display + FromPrimitive> TensionSpline<T> {
                 ExtrapolateMode::Nan => {
                     // Return NaN for points outside the interpolation domain
                     return Ok(T::nan());
+                }
+                ExtrapolateMode::Nearest => {
+                    let clamped = xval.max(self.x[0]).min(self.x[n - 1]);
+                    return self.derivative_single(deriv_order, clamped);
                 }
             }
         }

--- a/scirs2-interpolate/tests/test_issue3_nearest_mode.rs
+++ b/scirs2-interpolate/tests/test_issue3_nearest_mode.rs
@@ -1,0 +1,92 @@
+// Regression tests for Issue 3: interpnd ExtrapolateMode::Nearest
+// Clamp out-of-range coordinates to the grid boundary before interpolating.
+
+use approx::assert_abs_diff_eq;
+use scirs2_core::ndarray::{Array, Array1, Array2, IxDyn};
+use scirs2_interpolate::interpnd;
+
+#[test]
+fn rgi_nearest_clamp_above() {
+    let x = Array1::from_vec(vec![0.0, 1.0, 2.0]);
+    let values = Array::from_shape_vec(IxDyn(&[3]), vec![0.0, 10.0, 20.0]).unwrap();
+    let interp = interpnd::RegularGridInterpolator::new(
+        vec![x],
+        values,
+        interpnd::InterpolationMethod::Linear,
+        interpnd::ExtrapolateMode::Nearest,
+    )
+    .unwrap();
+
+    let xi = Array2::from_shape_vec((1, 1), vec![5.0]).unwrap();
+    let result = interp.__call__(&xi.view()).unwrap();
+    assert_abs_diff_eq!(result[0], 20.0, epsilon = 1e-10);
+}
+
+#[test]
+fn rgi_nearest_clamp_below() {
+    let x = Array1::from_vec(vec![0.0, 1.0, 2.0]);
+    let values = Array::from_shape_vec(IxDyn(&[3]), vec![0.0, 10.0, 20.0]).unwrap();
+    let interp = interpnd::RegularGridInterpolator::new(
+        vec![x],
+        values,
+        interpnd::InterpolationMethod::Linear,
+        interpnd::ExtrapolateMode::Nearest,
+    )
+    .unwrap();
+
+    let xi = Array2::from_shape_vec((1, 1), vec![-3.0]).unwrap();
+    let result = interp.__call__(&xi.view()).unwrap();
+    assert_abs_diff_eq!(result[0], 0.0, epsilon = 1e-10);
+}
+
+#[test]
+fn rgi_nearest_clamp_2d() {
+    let x = Array1::from_vec(vec![0.0, 1.0]);
+    let y = Array1::from_vec(vec![0.0, 1.0]);
+    let mut values = Array::zeros(IxDyn(&[2, 2]));
+    values[[0, 0].as_slice()] = 1.0;
+    values[[0, 1].as_slice()] = 2.0;
+    values[[1, 0].as_slice()] = 3.0;
+    values[[1, 1].as_slice()] = 4.0;
+
+    let interp = interpnd::RegularGridInterpolator::new(
+        vec![x, y],
+        values,
+        interpnd::InterpolationMethod::Linear,
+        interpnd::ExtrapolateMode::Nearest,
+    )
+    .unwrap();
+
+    // Both dims out of range above: clamp to (1,1), value = 4.0
+    let xi = Array2::from_shape_vec((1, 2), vec![5.0, 5.0]).unwrap();
+    let result = interp.__call__(&xi.view()).unwrap();
+    assert_abs_diff_eq!(result[0], 4.0, epsilon = 1e-10);
+
+    // Both dims out of range below: clamp to (0,0), value = 1.0
+    let xi2 = Array2::from_shape_vec((1, 2), vec![-1.0, -1.0]).unwrap();
+    let result2 = interp.__call__(&xi2.view()).unwrap();
+    assert_abs_diff_eq!(result2[0], 1.0, epsilon = 1e-10);
+
+    // In-bounds should still work
+    let xi3 = Array2::from_shape_vec((1, 2), vec![0.5, 0.5]).unwrap();
+    let result3 = interp.__call__(&xi3.view()).unwrap();
+    assert_abs_diff_eq!(result3[0], 2.5, epsilon = 1e-10);
+}
+
+#[test]
+fn rgi_nearest_with_nearest_method() {
+    let x = Array1::from_vec(vec![0.0, 1.0, 2.0]);
+    let values = Array::from_shape_vec(IxDyn(&[3]), vec![0.0, 10.0, 20.0]).unwrap();
+    let interp = interpnd::RegularGridInterpolator::new(
+        vec![x],
+        values,
+        interpnd::InterpolationMethod::Nearest,
+        interpnd::ExtrapolateMode::Nearest,
+    )
+    .unwrap();
+
+    // Should clamp then pick nearest grid point
+    let xi = Array2::from_shape_vec((1, 1), vec![5.0]).unwrap();
+    let result = interp.__call__(&xi.view()).unwrap();
+    assert_abs_diff_eq!(result[0], 20.0, epsilon = 1e-10);
+}


### PR DESCRIPTION
Add a Nearest clamp mode to the N-dimensional ExtrapolateMode enum that clamps out-of-range query coordinates to the grid boundary before interpolating. This is a common "no extrapolation" behavior and eliminates the need for callers to manually clamp coordinates.

Update all downstream match arms in boundarymode, hermite, multiscale, and tension modules to handle the new variant.

## Description
<!-- Briefly describe the changes in this PR -->

## Type of change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] AI/ML related functionality

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes -->
- [x] Unit tests
- [ ] Integration tests
- [ ] Performance tests (if relevant)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context
<!-- Add any other context about the PR here -->